### PR TITLE
fix: absolutely positioned table styles are now disabled in Safari

### DIFF
--- a/components/table-dataset-index.vue
+++ b/components/table-dataset-index.vue
@@ -175,6 +175,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+/*
+  Most of the table styles below are not supported by Safari. Therefore, table
+  styles are reset at the end of this <style> tag and safar-specific styles are
+  applied.
+*/
+
 // ///////////////////////////////////////////////////////////////////// General
 .table-deals {
   @include fontSize_Mini;
@@ -451,8 +457,6 @@ tr.divider {
   }
 }
 
-// ////////////////////////////////////////////////////////////////////// Common
-
 // //////////////////////////////////////////////////////////////////// Specific
 .filter-description {
   margin-top: -2.75rem;
@@ -517,5 +521,32 @@ tr.divider {
   @include tiny {
     margin-left: 0.5rem;
   }
+}
+
+// ////////////////////////////////////////////////////////////// Safari Browser
+@include Safari7Plus ('tbody:not(.divider):before') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:first-child:before') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:first-child:after') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:nth-child(3):after') {
+  display: none;
+}
+
+@include Safari7Plus ('.row-body') {
+  background-color: $aquaHaze;
+  transition: 100ms ease-out;
+}
+
+@include Safari7Plus ('.row-body:hover') {
+  background-color: $mystic;
+  transition: 100ms ease-in;
 }
 </style>

--- a/components/table-dataset-singular.vue
+++ b/components/table-dataset-singular.vue
@@ -233,6 +233,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+/*
+  Most of the table styles below are not supported by Safari. Therefore, table
+  styles are reset at the end of this <style> tag and safar-specific styles are
+  applied.
+*/
+
 // ///////////////////////////////////////////////////////////////////// General
 .table-deals {
   @include fontSize_Mini;
@@ -574,5 +580,32 @@ tr.divider {
 .dataset {
   @include fontSize_Tiny;
   @include leading_Large;
+}
+
+// ////////////////////////////////////////////////////////////// Safari Browser
+@include Safari7Plus ('tbody:not(.divider):before') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:first-child:before') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:first-child:after') {
+  display: none;
+}
+
+@include Safari7Plus ('.cell-parent:nth-child(3):after') {
+  display: none;
+}
+
+@include Safari7Plus ('.row-body') {
+  background-color: $aquaHaze;
+  transition: 100ms ease-out;
+}
+
+@include Safari7Plus ('.row-body:hover') {
+  background-color: $mystic;
+  transition: 100ms ease-in;
 }
 </style>


### PR DESCRIPTION
Safari is unable to handle absolutely positioned elements that are direct children of base table tags (`td`, `tr`, etc.). These table styles are disabled in Safari 7+ and replaced with more basic styles.