### PR TITLE
feat: filter nonexistent datasets

### DIFF
--- a/components/stats.vue
+++ b/components/stats.vue
@@ -52,7 +52,7 @@
                 </ul>
               </div>
             </div>
-            
+
           </div>
         </div>
       </div>

--- a/components/table-dataset-index.vue
+++ b/components/table-dataset-index.vue
@@ -29,7 +29,7 @@
             :key="deal.rank"
             class="row row-body"
             @click="navigateToDataset($event, deal.slug)">
-            
+
             <td
               v-for="cell in columns"
               :key="cell.slug"
@@ -136,11 +136,12 @@ export default {
     }),
     filtered () {
       const datasets = this.datasets
+      const source = Object.keys(this.datasetNames.manifest)
       if (!datasets) { return false }
       const filteredByValue = datasets.filter((obj) => {
         const slug = obj.slug.toLowerCase()
         const filter = this.filterValue.toLowerCase()
-        if (slug.includes(filter)) {
+        if (slug.includes(filter) && source.includes(obj.slug)) {
           return obj
         }
         return false


### PR DESCRIPTION
1 dataset (`monolith-vr-materials`) was not included in the source list (re: not approved) (`@/content/data/dataset-explorer-manifest.json`). Any datasets not included in the source list will not be displayed in the table.